### PR TITLE
ci: pin version of action-gh-release 

### DIFF
--- a/.github/workflows/publish-release-spec.yml
+++ b/.github/workflows/publish-release-spec.yml
@@ -23,7 +23,7 @@ jobs:
           mv dist/bundle.yaml dist/exalsius-openapi-${{ github.event.release.tag_name }}.yaml
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.2.2
         with:
           files: |
             dist/exalsius-openapi-${{ github.event.release.tag_name }}.yaml


### PR DESCRIPTION
The current version of action-gh-release a bug which prevents uploading the bundled api spec.

See: https://github.com/softprops/action-gh-release/issues/628 