### PR TITLE
feat: transform access-information to object(s)

### DIFF
--- a/openapi/components/schemas/workspace-access-information.yaml
+++ b/openapi/components/schemas/workspace-access-information.yaml
@@ -1,0 +1,33 @@
+type: object
+required:
+  - access_type
+  - port_name
+  - protocol
+properties:
+  access_type:
+    type: string
+    enum: [NODE_PORT]
+    x-enum-varnames: [NODE_PORT]
+    description: >
+      The type of access information.
+      - `NODE_PORT`: Node port access information
+  port_name:
+    type: string
+    description: The name of the port
+    example: "http"
+  port_description:
+    type: string
+    description: A description of the port
+    example: "Connects with the jupyter notebook UI."
+  protocol:
+    type: string
+    enum: [HTTP]
+    x-enum-varnames: [HTTP]
+    description: >
+      The protocol of the port
+      - `HTTP`: HTTP protocol
+  external_ip:
+    type: string
+    description: The external IP address associated with the port
+    example: "123.456.789.012"
+

--- a/openapi/components/schemas/workspace.yaml
+++ b/openapi/components/schemas/workspace.yaml
@@ -41,9 +41,11 @@ properties:
     description: The description of the workspace
     example: "This is a workspace for my project"
   access_information:
-    type: string
-    description: Information about how to access the workspace
-    example: "ssh -i ~/.ssh/id_rsa user@host"
+    type: array
+    items:
+      $ref: '../../components/schemas/workspace-access-information.yaml'
+    description: The access information for the workspace
+    example: [{"access_type": "NODE_PORT", "port_name": "http", "port_description": "Connects with the jupyter notebook UI.", "protocol": "HTTP", "external_ip": "123.456.789.012"}]
   resources:
     description: The resources allocated to the workspace
     $ref: './resource-pool.yaml'


### PR DESCRIPTION
Instead of a pure string representation, describe access information (of one or more ports) as objects and let the frontend / CLI take care of beautiful rendering.