### PR TITLE
fix: refine security scopes

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -253,6 +253,7 @@ components:
           tokenUrl: https://exalsius.eu.auth0.com/oauth/token
           scopes:
             openid: Request an ID token (mandatory for OIDC)
+            gpuradar: Scope used for GPU radar operations
             nodeagent: Scope used for node agent operations
 security:
   - OAuth2:

--- a/openapi/paths/nodes/node.yaml
+++ b/openapi/paths/nodes/node.yaml
@@ -116,7 +116,8 @@ patch:
   summary: Patch a node
   security:
     - OAuth2:
-      # This operation is only accessible with the nodeagent scope
+      # This operation is accessible by users (openid) and m2m applications with scope nodeagent
+      - openid
       - nodeagent
   description: |
     **Patch a node**

--- a/openapi/paths/offers.yaml
+++ b/openapi/paths/offers.yaml
@@ -2,6 +2,11 @@ get:
   operationId: getOffers
   tags: [offers]
   summary: List and filter current GPU on-demand and spot market offers
+  security:
+    - OAuth2:
+      # This operation is accessible by users (openid) and m2m applications with scope gpuradar
+      - openid
+      - gpuradar
   description: |
     **List GPU offers (on-demand & spot instances)**
     Retrieve current GPU instance offers from both on-demand and spot markets, with optional filters.

--- a/openapi/paths/performance-prediction.yaml
+++ b/openapi/paths/performance-prediction.yaml
@@ -1,5 +1,10 @@
 post:
   summary: Get performance predictions for a configuration
+  security:
+    - OAuth2:
+      # This operation is accessible by users (openid) and m2m applications with scope gpuradar
+      - openid
+      - gpuradar
   description: >
     This endpoint returns predicted runtime and memory usage
     for a given configuration of model, optimizer, batch size, and sequence length.


### PR DESCRIPTION
Add scopes to particular endpoints, so M2M applications no longer have wildcard access.